### PR TITLE
Fix for bug #25 - Layout issue in compact view

### DIFF
--- a/src/Inventory.App/Styles/NavigationView.xaml
+++ b/src/Inventory.App/Styles/NavigationView.xaml
@@ -34,6 +34,7 @@
                                 <VisualState x:Name="Minimal">
                                     <VisualState.Setters>
                                         <Setter Target="HeaderContent.Margin" Value="48,0,0,0"/>
+                                        <Setter Target="ContentGrid.Margin" Value="0,48,0,0" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>


### PR DESCRIPTION
Updated layout margin of content grid to set 48 top margin in minimal view to prevent overlapping of content view.