### PR TITLE
Removed unnecessary Setter in InventorySample NavigationView default UWP Style

### DIFF
--- a/src/Inventory.App/Styles/NavigationView.xaml
+++ b/src/Inventory.App/Styles/NavigationView.xaml
@@ -84,7 +84,6 @@
                                 <VisualState x:Name="TitleBarVisible"/>
                                 <VisualState x:Name="TitleBarCollapsed">
                                     <VisualState.Setters>
-                                        <Setter Target="PaneButtonGrid.Margin" Value="0,32,0,0"/>
                                         <Setter Target="PaneContentGrid.Margin" Value="0,32,0,0"/>
                                     </VisualState.Setters>
                                 </VisualState>


### PR DESCRIPTION
### Removed unnecessary Setter in InventorySample NavigationView default UWP Style

Removed PaneButtonGrid.Margin in the VisualState Setters for the default UWP NavigationView Style.
PaneButtonGrid does not exist in the NavigationView template and in the code behind of the control.

![image](https://user-images.githubusercontent.com/16295702/49771148-cfc6ea00-fcb5-11e8-8276-08689f5c9ecb.png)

![image](https://user-images.githubusercontent.com/16295702/49771160-d81f2500-fcb5-11e8-82b1-850a43644488.png)

Related to those previous PRs :
- WinUI : https://github.com/Microsoft/microsoft-ui-xaml/pull/46
-  WindowsCommunityToolkit : https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/2706